### PR TITLE
Limit the number of search queries to 5

### DIFF
--- a/src/components/QuerySelectorList/QuerySelectorList.tsx
+++ b/src/components/QuerySelectorList/QuerySelectorList.tsx
@@ -7,15 +7,16 @@ import { QueriesContext } from "src/contexts/queries/queries";
 
 const QuerySelectorList = () => {
   const { queries, addQuery } = useContext(QueriesContext);
+  const MAX_QUERIES = 5;
 
   return (
     <menu className="grid grid-flow-col auto-cols-max gap-2 items-center mt-5">
       {Array.from(queries.entries()).map(([key]) => (
         <QuerySelector key={key} name="Search Query" queryId={key} />
       ))}
-      <button className="text-[24px] dark:text-white" onClick={addQuery}>
+      {queries.size < MAX_QUERIES && <button className="text-[24px] dark:text-white" onClick={addQuery}>
         <Add />
-      </button>
+      </button>}
     </menu>
   );
 };


### PR DESCRIPTION
# Description
Limited the number of search queries by hiding the add button when the number of queries reaches 5

![Screenshot from 2022-02-12 23-42-22](https://user-images.githubusercontent.com/41417417/153743894-22217a7b-04e6-488d-bc17-23e711f442bc.png)

# Issue
Resolves #20 

# Note 
Let me know if you think the maximum number of queries of 5 should be adjusted. I just thought 5 sounds like a good number and more than that makes the bars look too small. 