### PR TITLE
fix: ensure a query is selected after adding or removing a query

### DIFF
--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -117,7 +117,7 @@ const chartColorsMultipleLight = [
 const Graph = () => {
   const { queries, updateQueryState } = useContext(QueriesContext);
 
-  const [queryIdsValue, setQueryIdsValue] = useState<string[]>([]);
+  const [queryIdsValue, setQueryIdsValue] = useState<number[]>([]);
   const [gradeValues, setGradeValues] = useState<gradeValue[]>([]);
 
   const { colorScheme } = useContext(ColorSchemeContext);
@@ -125,7 +125,7 @@ const Graph = () => {
   const props = colorScheme === "dark" ? optionsDark : optionsLight;
 
   useEffect(() => {
-    const queryIds: string[] = [];
+    const queryIds: number[] = [];
     queries.forEach((_value, key) => {
       queryIds.push(key);
     });

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -210,7 +210,7 @@ const Graph = () => {
   return (
     <DynamicComponent
       data={gradeValues}
-      keys={queryIdsValue}
+      keys={queryIdsValue.map((id) => id.toString())}
       groupMode="grouped"
       margin={{
         top: 0,

--- a/src/components/QuerySelector/QuerySelector.tsx
+++ b/src/components/QuerySelector/QuerySelector.tsx
@@ -31,7 +31,9 @@ const Query = ({ name, queryId, color }: QueryProps) => {
         )}
         {name}
         <button
-          onClick={() => {
+          onClick={(e) => {
+            // Prevent click event from bubbling to parent div. This is sort of a hacky solution, but it should work until we redesign the tabs.
+            e.stopPropagation();
             removeQuery(queryId);
           }}
         >

--- a/src/contexts/queries/QueriesProvider.tsx
+++ b/src/contexts/queries/QueriesProvider.tsx
@@ -66,19 +66,20 @@ function QueriesProvider({ children, initialQueries }: QueriesProviderProps) {
   const removeQuery = (queryId: any) => {
     let newQueries = new Map(queries);
     newQueries.delete(queryId);
-    newQueries = new Map([
-      [
-        new Date().getTime(),
-        {
-          instructors: [],
-          quarters: [],
-          years: [],
-          departments: [],
-          courseCode: [],
-          classCode: [],
-        },
-      ],
-    ]);
+    if (newQueries.size === 0)
+      newQueries = new Map([
+        [
+          new Date().getTime(),
+          {
+            instructors: [],
+            quarters: [],
+            years: [],
+            departments: [],
+            courseCode: [],
+            classCode: [],
+          },
+        ],
+      ]);
     const lastQueryId = Array.from(newQueries.keys()).pop();
     setQueries(newQueries);
     setSelectedQuery(lastQueryId);

--- a/src/contexts/queries/QueriesProvider.tsx
+++ b/src/contexts/queries/QueriesProvider.tsx
@@ -19,7 +19,7 @@ function QueriesProvider({ children, initialQueries }: QueriesProviderProps) {
   const [queries, setQueries] = useState<Queries>(new Map(initialQueries));
   const [states, setStates] = useState<QueryStates>(new Map());
   const [selectedQuery, setSelectedQuery] = useState(
-    initialQueries.keys().next().value
+    Array.from(initialQueries.keys()).shift()
   );
 
   const updateQuery = (
@@ -49,8 +49,9 @@ function QueriesProvider({ children, initialQueries }: QueriesProviderProps) {
   };
 
   const addQuery = () => {
+    const queryId = new Date().getTime();
     const newQueries = new Map(queries);
-    newQueries.set(new Date(), {
+    newQueries.set(queryId, {
       instructors: [],
       quarters: [],
       years: [],
@@ -59,12 +60,28 @@ function QueriesProvider({ children, initialQueries }: QueriesProviderProps) {
       classCode: [],
     });
     setQueries(newQueries);
+    setSelectedQuery(queryId);
   };
 
   const removeQuery = (queryId: any) => {
-    const newQueries = new Map(queries);
+    let newQueries = new Map(queries);
     newQueries.delete(queryId);
+    newQueries = new Map([
+      [
+        new Date().getTime(),
+        {
+          instructors: [],
+          quarters: [],
+          years: [],
+          departments: [],
+          courseCode: [],
+          classCode: [],
+        },
+      ],
+    ]);
+    const lastQueryId = Array.from(newQueries.keys()).pop();
     setQueries(newQueries);
+    setSelectedQuery(lastQueryId);
   };
 
   return (

--- a/src/contexts/queries/queries.ts
+++ b/src/contexts/queries/queries.ts
@@ -10,7 +10,7 @@ import {
 
 const defaultQueries: Queries = new Map([
   [
-    new Date(),
+    new Date().getTime(),
     {
       instructors: [],
       quarters: [],
@@ -24,7 +24,7 @@ const defaultQueries: Queries = new Map([
 
 const defaultStates: QueryStates = new Map([
   [
-    new Date(),
+    new Date().getTime(),
     {
       loading: false,
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ const Home: NextPage = () => {
       initialQueries={
         new Map([
           [
-            new Date(),
+            new Date().getTime(),
             {
               instructors: [],
               quarters: [],

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from "react";
 
-export type Queries = Map<any, Query>;
-export type QueryStates = Map<any, QueryState>;
+export type Queries = Map<number, Query>;
+export type QueryStates = Map<number, QueryState>;
 
 export interface Query {
   instructors: Option[];


### PR DESCRIPTION
- [x] Newly created queries are automatically selected
- [x] If the currently selected query is deleted, the last one on the list is selected
- [x] If there's only one query and it's deleted, a blank query is created

This PR also changes the map key to `Date.getTime()`, from `Date`. This should fix some edge cases where queries created in the same second behave weirdly.