### PR TITLE
Fix #69 and minor Firefox graph styling issue

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,8 +6,8 @@ import poweredByVercel from "./poweredByVercel.svg";
 
 const Footer = () => {
   return (
-    <footer className="z-50 flex items-center justify-between w-full h-16 text-sm dark:text-neutral-200 content">
-      <span>
+    <footer className="footer z-50 flex flex-col sm:flex-row items-center justify-between w-full h-16 text-sm dark:text-neutral-200 content">
+      <span className="mb-2 sm:mb-0">
         Maintained by{" "}
         <a href="https://icssc.club/?utm_source=icssc">ICSSC</a> in{" "}
         <Sun className="inline" fill="currentColor" size={16} /> Irvine,

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -224,7 +224,7 @@ const Graph = () => {
       groupMode="grouped"
       margin={{
         top: 0,
-        bottom: 20,
+        bottom: 30,
         left: 50,
         right: 50,
       }}


### PR DESCRIPTION
This PR makes the footer text render vertically when on mobile and also fixes an issue where the x-axis text gets cut off on Firefox browser.

**Footer after changes:**

![image](https://github.com/icssc/Zotistics/assets/21994085/29933112-dfdf-47e8-9f5d-9935a1d166d0)

Also noticed this small visual bug when browsing from Firefox where the x-axis text was being cut off. Easiest solution was to just give it slightly more bottom margin

**Before:**
![image](https://github.com/icssc/Zotistics/assets/21994085/087b76e2-2d79-4230-b718-2ad74cd4605a)

**After:**
![image](https://github.com/icssc/Zotistics/assets/21994085/c4a23f2e-0b36-41cf-8854-6910d36daf4e)
 
Closes #69 
